### PR TITLE
Add option to use a list of reduction strategies

### DIFF
--- a/server/README-FR.md
+++ b/server/README-FR.md
@@ -25,7 +25,7 @@ DEBUG=xcarpaccio:server npm start
 
 Durant l'atelier, des paquets HTTP vont être échangé entre les ordinateurs des participants et celui hébergeant le serveur. Cependant nombreux sont les réseaux qui bloquent les requêtes entrantes au moyen de firewall, ce qui empêchera le serveur de joindre les ordinateurs des participants.
 
-Avant de commencer l'atelier, il est fortement conseillé de tester le réseau que vous comptez utiliser, afin de vérifier qui accepte les requêtes entrantes. Pour cela suivez les instructions suivantes : 
+Avant de commencer l'atelier, il est fortement conseillé de tester le réseau que vous comptez utiliser, afin de vérifier qui accepte les requêtes entrantes. Pour cela suivez les instructions suivantes :
 
 1. Connectez un premier ordinateur au réseau en question
 2. Sur cet ordinateur lancez: `$ echo "Hello Extreme Carpaccio" | nc -l 3000`
@@ -39,30 +39,46 @@ Les participants vont prendre du temps pour mettre en place leur machine, et cer
 
 En tant que facilitateur, vous pouvez souhaiter que tous commencent en même temps, malgré les problèmes de certains, pour le jeu soit équitable pour tous.
 
-Vous pouvez le faire de la façon suivante : 
+Vous pouvez le faire de la façon suivante :
 
 1. Ouvrez le ficher `configuration.json`.
-2. Remplacez  `"cashFreeze": false` par  `"cashFreeze": true` puis sauvez le fichier.
+2. Remplacez `"cashFreeze": false` par `"cashFreeze": true` puis sauvez le fichier.
 3. Lancez le jeu avec `npm start`.
 4. Faites que tous s'enregistre sur le serveur central.
-5. Grace au paramètre ``cashFreeze`` les scores restent à 0.
+5. Grace au paramètre `cashFreeze` les scores restent à 0.
 6. Attendez que toutes équipes se soient enregistrées et qu'elles soient marqué **online** sur le dashboard. Le jeu est alors configuré pour tous.
-7. Dites *"Il semblerait que tout le monde soit prêt, je vais lancer le jeu dans 5 secondes."*.
+7. Dites _"Il semblerait que tout le monde soit prêt, je vais lancer le jeu dans 5 secondes."_.
 8. Ré-ouvrez le ficher `configuration.json`.
-9. Remplacez  `"cashFreeze": true` par  `"cashFreeze": false` puis sauvez le fichier.
+9. Remplacez `"cashFreeze": true` par `"cashFreeze": false` puis sauvez le fichier.
 10. Le score des joueurs est maintenant évolutif, le jeu commence !
 
 ## L'Atelier
 
 L'Extreme Carpaccio est pensé pour être joué avec des Product Owners (PO) et des Développeurs. Il peut être joué avec seulement des Développeurs, mais les stratégies auront alors tendance à être plus biaisées, puisque les développeurs ont plus tendance à se focaliser sur le code, plus que sur le produit ou les itérations.
 
-L'atelier se décompose en trois étapes principales : le découpage, l'implémentation et la rétrospective. Une session normal prend entre 1:30 et 3:00 heures. 
+L'atelier se décompose en trois étapes principales : le découpage, l'implémentation et la rétrospective. Une session normal prend entre 1:30 et 3:00 heures.
+
+### Début
 
 Au début le facilitateur présente le problème à résoudre aux participants. Les participants forment alors des équipes de 2 à 4 (idéalement) personnes et essayent de comprendre et de découper le problème. Ensemble ils définissent une stratégie d'implémentation, en faisant des compromis entre la valeur produit et de défis techniques.
 
 Ensuite le facilitateur démarre le serveur et fait en sorte que toutes les équipes soient capables d'échanger des messages HTTP avec le serveur central. Une fois que tout le monde est prêt, le facilitateur autorise les équipes à commencer à implémenter leurs solutions (peut demander un redémarrage du serveur pour remettre les scores à 0) et les gens commencent à jouer.
 
+### Contraintes
+
 Durant la session, le facilitateur peut activer des "contraintes" depuis le fichier [configuration.json file](https://github.com/dlresende/extreme-carpaccio/blob/master/server/configuration.json), de façon à pimenter un peu le jeu et rajouter un peu de chaos. Quelques exemples : envoyer de mauvaises requêtes (**les participants doivent alors renvoyer une 400 - bad request**), changer la stratégie de réduction, changer le calcul des taxes, pénaliser le downtime etc. Tout changement au fichier de configuration est automatiquement pris en compte, sans nécessité de redémarrage du serveur. C'est à la discrétion du facilitateur d'annoncer ou pas les changements, dépendant de comment il souhaite mener la session.
+
+### Stratégies de réduction
+
+Les possibles stratégies de réduction sont:
+
+- `STANDARD` (par défaut),
+- `HALF PRICE`
+- `PAY THE PRICE`
+
+Le facilitateur peut en spécifier une seule (ex. `"STANDARD"`), ou un tableau de stratégies possibles (ex. `["HALF PRICE, "PAY THE PRICE"]`) via le fichier [configuration.json](https://github.com/dlresende/extreme-carpaccio/blob/master/server/configuration.json).
+
+### Conclusion et rétrospective
 
 A la fin, quand le facilitateur décide d'arrêter la partie implémentation, et que l'équipe victorieuse est déclarée, le facilitateur prend le temps d'échanger avec les participants à propos de l'exercice : ce qui a fonctionné, ce qui pourrait être amélioré, leurs feedbacks, leurs apprentissages, etc.
 

--- a/server/README.md
+++ b/server/README.md
@@ -5,6 +5,7 @@
 French version [here](./README-FR.md).
 
 ## Requirements
+
 - [nodejs](https://nodejs.org/en/)
 
 ## Install & Run
@@ -13,6 +14,7 @@ French version [here](./README-FR.md).
 npm install
 npm start
 ```
+
 Start in debug mode (activate debug mode for `xcarpaccio:server`):
 
 ```
@@ -20,6 +22,7 @@ DEBUG=xcarpaccio:server npm start
 ```
 
 ## Test the network
+
 During the workshop, HTTP packages will be exchanged between participant's computers and the server. Although, many networks block incoming connections using firewalls, which will prevent the server from reaching participants.
 
 Before you start an Extreme Carpaccio workshop, it is strongly recommended that you test if the network you will playing with accepts incoming connections. Follow the instructions bellow.
@@ -38,27 +41,44 @@ As a facilitator, you may want everyone to be ready before starting the game, to
 
 You can do this this way:
 
-1. Open ``configuration.json`` file 
-1. Replace ``"cashFreeze": false,`` with ``"cashFreeze": true,`` and save
-1. Start the game server with ``npm start``
+1. Open `configuration.json` file
+1. Replace `"cashFreeze": false,` with `"cashFreeze": true,` and save
+1. Start the game server with `npm start`
 1. Make everyone register
-1. Thanks to the ``cashFreeze`` parameter, everyone's cash stays at 0.
+1. Thanks to the `cashFreeze` parameter, everyone's cash stays at 0.
 1. Wait until every team is registered **and marked online**. This means the game is setup for everyone.
-1. Say '*Looks like that everyone is ready. Then I will start the game in 5 seconds.*' 
-1. Open ``configuration.json`` file 
-1. Replace ``"cashFreeze": true,`` with ``"cashFreeze": false,`` and save
+1. Say '_Looks like that everyone is ready. Then I will start the game in 5 seconds._'
+1. Open `configuration.json` file
+1. Replace `"cashFreeze": true,` with `"cashFreeze": false,` and save
 1. Player's cash is now evaluated. The game starts!
 
 ## Workshop
+
 Extreme Carpaccio is intended to be played with Product Owners (PO) and Developers together. It can be played with only Developers, but slicing strategies tend to be more biased since developers generally focus more on code and than on product and iterations.
 
 The workshop has mainly 3 stages: slicing, implementation and retrospective. A session normally takes between 1:30 and 3:00 hours.
+
+### Start
 
 At the beginning, the facilitator exposes the problem to be solved to participants. The participants then form teams between 2-4 (ideally) and try to understand and slice the problem, and together define an implementation strategy, based on product value perspective and technical challenges trade-offs.
 
 Next, the facilitator starts the server and makes sure all the teams are able to exchange HTTP messages with the server. Once everyone is ready, the facilitator allows teams to start implementing (normally requires restarting the server to reset the score) and people start playing.
 
+### Constraints
+
 During the session, the facilitator can activate some "constraints" via the [configuration.json file](https://github.com/dlresende/extreme-carpaccio/blob/master/server/configuration.json), in order to bring some chaos to the game and shake the score. Some examples are: send bad requests (**in which case participants should respond 400 - bad request**); change reduction strategies; change tax rules; charge downtime; etc. Any change to this file is automatically taken into account, no need to restart the server. It is up to the facilitator to announce when he/she triggers a constraint, based on how he/she wants to conduct the session.
+
+### Reduction Strategies
+
+Available reduction strategies are:
+
+- `STANDARD` (default),
+- `HALF PRICE`
+- `PAY THE PRICE`
+
+You can specify either only one of them (e.g. `"STANDARD"`), or an array of them (e.g. `["HALF PRICE, "PAY THE PRICE"]`) in the [configuration.json file](https://github.com/dlresende/extreme-carpaccio/blob/master/server/configuration.json).
+
+### Conclusion and retrospective
 
 At the end, when the facilitator decides to stop the implementation session and the winner becomes known, he/she takes some time at to exchange with participants about the exercise: what worked well, what could be improved, feedbacks, learnings, etc.
 

--- a/server/apps/backend/src/config.ts
+++ b/server/apps/backend/src/config.ts
@@ -19,7 +19,7 @@ export enum BadRequestMode {
 export type Settings = {
   active?: boolean;
   cashFreeze?: boolean;
-  reduction?: string;
+  reduction?: string | string[];
   offlinePenalty?: number;
   badRequest?: {
     active?: boolean;

--- a/server/apps/backend/src/services/dispatcher/Dispatcher.spec.ts
+++ b/server/apps/backend/src/services/dispatcher/Dispatcher.spec.ts
@@ -56,15 +56,14 @@ describe('Dispatcher', () => {
         false
       );
     });
-    it('should randomly send one of the reduction strategies when using an array', () => {
+    it('should send one of the reduction strategies when using an array', () => {
       jest.spyOn(configuration, 'all').mockReturnValue({
-        reduction: ['HALF PRICE', 'PAY THE PRICE'],
+        reduction: ['PAY THE PRICE'],
         badRequest: {
           active: false,
         },
         active: true,
       });
-      jest.spyOn(global.Math, 'random').mockReturnValue(0.5);
       jest
         .spyOn(dispatcher, 'sendOrderToSellers')
         .mockImplementation(jest.fn());

--- a/server/apps/backend/src/services/dispatcher/Dispatcher.spec.ts
+++ b/server/apps/backend/src/services/dispatcher/Dispatcher.spec.ts
@@ -35,23 +35,88 @@ describe('Dispatcher', () => {
     expect(dispatcher.sendOrderToSellers).not.toHaveBeenCalled();
   });
 
-  it('should load configuration for reductions', () => {
-    jest.spyOn(configuration, 'all').mockReturnValue({
-      reduction: 'HALF PRICE',
-      badRequest: {
-        active: false,
-      },
-      active: true,
+  describe('when loading configuration for reductions', () => {
+    it('should send the specified reduction when it is a string', () => {
+      jest.spyOn(configuration, 'all').mockReturnValue({
+        reduction: 'HALF PRICE',
+        badRequest: {
+          active: false,
+        },
+        active: true,
+      });
+      jest
+        .spyOn(dispatcher, 'sendOrderToSellers')
+        .mockImplementation(jest.fn());
+
+      dispatcher.startBuying(1);
+
+      expect(dispatcher.sendOrderToSellers).toHaveBeenCalledWith(
+        Reductions.HALF_PRICE,
+        1,
+        false
+      );
     });
-    jest.spyOn(dispatcher, 'sendOrderToSellers').mockImplementation(jest.fn());
+    it('should randomly send one of the reduction strategies when using an array', () => {
+      jest.spyOn(configuration, 'all').mockReturnValue({
+        reduction: ['HALF PRICE', 'PAY THE PRICE'],
+        badRequest: {
+          active: false,
+        },
+        active: true,
+      });
+      jest.spyOn(global.Math, 'random').mockReturnValue(0.5);
+      jest
+        .spyOn(dispatcher, 'sendOrderToSellers')
+        .mockImplementation(jest.fn());
 
-    dispatcher.startBuying(1);
+      dispatcher.startBuying(1);
 
-    expect(dispatcher.sendOrderToSellers).toHaveBeenCalledWith(
-      Reductions.HALF_PRICE,
-      1,
-      false
-    );
+      expect(dispatcher.sendOrderToSellers).toHaveBeenCalledWith(
+        Reductions.PAY_THE_PRICE,
+        1,
+        false
+      );
+    });
+    it('should send the STANDARD strategy when it does not recognize the strategy passed in config', () => {
+      jest.spyOn(configuration, 'all').mockReturnValue({
+        reduction: 'UNKNOWN STRATEGY',
+        badRequest: {
+          active: false,
+        },
+        active: true,
+      });
+      jest
+        .spyOn(dispatcher, 'sendOrderToSellers')
+        .mockImplementation(jest.fn());
+
+      dispatcher.startBuying(1);
+
+      expect(dispatcher.sendOrderToSellers).toHaveBeenCalledWith(
+        Reductions.STANDARD,
+        1,
+        false
+      );
+    });
+    it('should send the STANDARD strategy when the provided strategy is undefined', () => {
+      jest.spyOn(configuration, 'all').mockReturnValue({
+        reduction: undefined,
+        badRequest: {
+          active: false,
+        },
+        active: true,
+      });
+      jest
+        .spyOn(dispatcher, 'sendOrderToSellers')
+        .mockImplementation(jest.fn());
+
+      dispatcher.startBuying(1);
+
+      expect(dispatcher.sendOrderToSellers).toHaveBeenCalledWith(
+        Reductions.STANDARD,
+        1,
+        false
+      );
+    });
   });
 
   it('should broadcast a bad request', () => {

--- a/server/apps/backend/src/services/dispatcher/Dispatcher.ts
+++ b/server/apps/backend/src/services/dispatcher/Dispatcher.ts
@@ -128,9 +128,7 @@ class Dispatcher {
   private getReductionStrategy(): string | undefined {
     const reductionStrategy = this.getConfiguration(this).reduction;
     if (Array.isArray(reductionStrategy)) {
-      return reductionStrategy[
-        Math.floor(Math.random() * reductionStrategy.length)
-      ];
+      return _.sample(reductionStrategy);
     }
     return reductionStrategy;
   }

--- a/server/apps/backend/src/services/dispatcher/Dispatcher.ts
+++ b/server/apps/backend/src/services/dispatcher/Dispatcher.ts
@@ -75,7 +75,7 @@ class Dispatcher {
   }
 
   public startBuying(iteration: number) {
-    const reductionStrategy = this.getConfiguration(this).reduction;
+    const reductionStrategy = this.getReductionStrategy();
     const period = this.getReductionPeriodFor(reductionStrategy);
     const badRequest = this.badRequest.shouldSendBadRequest(iteration);
     let message = `>>> Shopping iteration ${iteration}`;
@@ -123,6 +123,16 @@ class Dispatcher {
 
       self.sellerService.setOffline(seller, offlinePenalty, currentIteration);
     };
+  }
+
+  private getReductionStrategy(): string | undefined {
+    const reductionStrategy = this.getConfiguration(this).reduction;
+    if (Array.isArray(reductionStrategy)) {
+      return reductionStrategy[
+        Math.floor(Math.random() * reductionStrategy.length)
+      ];
+    }
+    return reductionStrategy;
   }
 
   private getReductionPeriodFor(reductionStrategy?: string): Period {


### PR DESCRIPTION
**Add option to use a list of reduction strategies, instead of just one at a time**

resolves #3 

This PR makes it possible for the facilitator to either use one reduction strategy (as a string) or an array of strategies, which will then send one randomly picked from the array provided.

I've added unit tests (using TDD) for the different scenarios, a new `getReductionStrategy()` private function in the dispatcher and more information in the README.

I haven't worked with TS much, so let me know if there's something I should do better!