### PR TITLE
feat: add weighted reduction option

### DIFF
--- a/server/README-FR.md
+++ b/server/README-FR.md
@@ -66,7 +66,7 @@ Ensuite le facilitateur démarre le serveur et fait en sorte que toutes les équ
 
 ### Contraintes
 
-Durant la session, le facilitateur peut activer des "contraintes" depuis le fichier [configuration.json file](https://github.com/dlresende/extreme-carpaccio/blob/master/server/configuration.json), de façon à pimenter un peu le jeu et rajouter un peu de chaos. Quelques exemples : envoyer de mauvaises requêtes (**les participants doivent alors renvoyer une 400 - bad request**), changer la stratégie de réduction, changer le calcul des taxes, pénaliser le downtime etc. Tout changement au fichier de configuration est automatiquement pris en compte, sans nécessité de redémarrage du serveur. C'est à la discrétion du facilitateur d'annoncer ou pas les changements, dépendant de comment il souhaite mener la session.
+Durant la session, le facilitateur peut activer des "contraintes" depuis le fichier [configuration.json file](server/apps/backend/configuration.json), de façon à pimenter un peu le jeu et rajouter un peu de chaos. Quelques exemples : envoyer de mauvaises requêtes (**les participants doivent alors renvoyer une 400 - bad request**), changer la stratégie de réduction, changer le calcul des taxes, pénaliser le downtime etc. Tout changement au fichier de configuration est automatiquement pris en compte, sans nécessité de redémarrage du serveur. C'est à la discrétion du facilitateur d'annoncer ou pas les changements, dépendant de comment il souhaite mener la session.
 
 ### Stratégies de réduction
 
@@ -76,9 +76,9 @@ Les possibles stratégies de réduction sont:
 - `HALF PRICE`
 - `PAY THE PRICE`
 
-Via le fichier [configuration.json](https://github.com/dlresende/extreme-carpaccio/blob/master/server/configuration.json), le facilitateur peut spécifier:
+Via le fichier [configuration.json](server/configuration.json), le facilitateur peut spécifier:
 
-- une seule (ex. `"STANDARD"`)
+- une seule stratégie (ex. `"STANDARD"`)
 - un tableau de stratégies possibles (ex. `["HALF PRICE, "PAY THE PRICE"]`)
 - un tableau de réductions et pondération (entre 0 et 1) (ex. `[{"reduction":"HALF PRICE, "weight":0.1}, {"reduction":"PAY THE PRICE", "weight":0.5}]`)
 

--- a/server/README-FR.md
+++ b/server/README-FR.md
@@ -76,7 +76,11 @@ Les possibles stratégies de réduction sont:
 - `HALF PRICE`
 - `PAY THE PRICE`
 
-Le facilitateur peut en spécifier une seule (ex. `"STANDARD"`), ou un tableau de stratégies possibles (ex. `["HALF PRICE, "PAY THE PRICE"]`) via le fichier [configuration.json](https://github.com/dlresende/extreme-carpaccio/blob/master/server/configuration.json).
+Via le fichier [configuration.json](https://github.com/dlresende/extreme-carpaccio/blob/master/server/configuration.json), le facilitateur peut spécifier:
+
+- une seule (ex. `"STANDARD"`)
+- un tableau de stratégies possibles (ex. `["HALF PRICE, "PAY THE PRICE"]`)
+- un tableau de réductions et pondération (entre 0 et 1) (ex. `[{"reduction":"HALF PRICE, "weight":0.1}, {"reduction":"PAY THE PRICE", "weight":0.5}]`)
 
 ### Conclusion et rétrospective
 

--- a/server/README.md
+++ b/server/README.md
@@ -66,7 +66,7 @@ Next, the facilitator starts the server and makes sure all the teams are able to
 
 ### Constraints
 
-During the session, the facilitator can activate some "constraints" via the [configuration.json file](https://github.com/dlresende/extreme-carpaccio/blob/master/server/configuration.json), in order to bring some chaos to the game and shake the score. Some examples are: send bad requests (**in which case participants should respond 400 - bad request**); change reduction strategies; change tax rules; charge downtime; etc. Any change to this file is automatically taken into account, no need to restart the server. It is up to the facilitator to announce when he/she triggers a constraint, based on how he/she wants to conduct the session.
+During the session, the facilitator can activate some "constraints" via the [configuration.json file](server/apps/backend/configuration.json), in order to bring some chaos to the game and shake the score. Some examples are: send bad requests (**in which case participants should respond 400 - bad request**); change reduction strategies; change tax rules; charge downtime; etc. Any change to this file is automatically taken into account, no need to restart the server. It is up to the facilitator to announce when he/she triggers a constraint, based on how he/she wants to conduct the session.
 
 ### Reduction Strategies
 
@@ -76,10 +76,10 @@ Available reduction strategies are:
 - `HALF PRICE`
 - `PAY THE PRICE`
 
-In the [configuration.json file](https://github.com/dlresende/extreme-carpaccio/blob/master/server/configuration.json), you can specify either:
+In the [configuration.json file](server/configuration.json), you can specify either:
 
-- only one of them (e.g. `"STANDARD"`),
-- an array of them (e.g. `["HALF PRICE, "PAY THE PRICE"]`)
+- only one reduction strategy (e.g. `"STANDARD"`),
+- an array of reduction strategie (e.g. `["HALF PRICE, "PAY THE PRICE"]`)
 - an array of reductions and weights (between 0 and 1) (e.g. `[{"reduction":"HALF PRICE, "weight":0.1}, {"reduction":"PAY THE PRICE", "weight":0.5}]`)
 
 ### Conclusion and retrospective

--- a/server/README.md
+++ b/server/README.md
@@ -76,7 +76,11 @@ Available reduction strategies are:
 - `HALF PRICE`
 - `PAY THE PRICE`
 
-You can specify either only one of them (e.g. `"STANDARD"`), or an array of them (e.g. `["HALF PRICE, "PAY THE PRICE"]`) in the [configuration.json file](https://github.com/dlresende/extreme-carpaccio/blob/master/server/configuration.json).
+In the [configuration.json file](https://github.com/dlresende/extreme-carpaccio/blob/master/server/configuration.json), you can specify either:
+
+- only one of them (e.g. `"STANDARD"`),
+- an array of them (e.g. `["HALF PRICE, "PAY THE PRICE"]`)
+- an array of reductions and weights (between 0 and 1) (e.g. `[{"reduction":"HALF PRICE, "weight":0.1}, {"reduction":"PAY THE PRICE", "weight":0.5}]`)
 
 ### Conclusion and retrospective
 

--- a/server/apps/backend/src/config.ts
+++ b/server/apps/backend/src/config.ts
@@ -3,6 +3,11 @@ import colors from 'colors';
 import logger from './logger';
 import utils from './utils';
 
+export type WeightedReduction = {
+  reduction: string;
+  weight: number;
+};
+
 export enum BadRequestMode {
   EMPTY_OBJECT = 0,
   ARRAY_BOOLEANS = 1,
@@ -19,7 +24,7 @@ export enum BadRequestMode {
 export type Settings = {
   active?: boolean;
   cashFreeze?: boolean;
-  reduction?: string | string[];
+  reduction?: string | string[] | WeightedReduction[];
   offlinePenalty?: number;
   badRequest?: {
     active?: boolean;

--- a/server/apps/backend/src/services/dispatcher/Dispatcher.spec.ts
+++ b/server/apps/backend/src/services/dispatcher/Dispatcher.spec.ts
@@ -76,6 +76,26 @@ describe('Dispatcher', () => {
         false
       );
     });
+    it('should send one of the reduction strategies when using a weight', () => {
+      jest.spyOn(configuration, 'all').mockReturnValue({
+        reduction: [{ reduction: 'PAY THE PRICE', weight: 0.1 }],
+        badRequest: {
+          active: false,
+        },
+        active: true,
+      });
+      jest
+        .spyOn(dispatcher, 'sendOrderToSellers')
+        .mockImplementation(jest.fn());
+
+      dispatcher.startBuying(1);
+
+      expect(dispatcher.sendOrderToSellers).toHaveBeenCalledWith(
+        Reductions.PAY_THE_PRICE,
+        1,
+        false
+      );
+    });
     it('should send the STANDARD strategy when it does not recognize the strategy passed in config', () => {
       jest.spyOn(configuration, 'all').mockReturnValue({
         reduction: 'UNKNOWN STRATEGY',

--- a/server/apps/backend/src/services/dispatcher/Dispatcher.spec.ts
+++ b/server/apps/backend/src/services/dispatcher/Dispatcher.spec.ts
@@ -76,6 +76,21 @@ describe('Dispatcher', () => {
         false
       );
     });
+    it('should create a weighted array of reduction strategies when using a weight', () => {
+      const reductionStrategy = [
+        { reduction: 'PAY THE PRICE', weight: 0.03 },
+        { reduction: 'STANDARD', weight: 0.01 },
+      ];
+      const weightedArray = [
+        'PAY THE PRICE',
+        'PAY THE PRICE',
+        'PAY THE PRICE',
+        'STANDARD',
+      ];
+      const returnedArray = dispatcher.getWeightedReduction(reductionStrategy);
+
+      expect(returnedArray).toEqual(weightedArray);
+    });
     it('should send one of the reduction strategies when using a weight', () => {
       jest.spyOn(configuration, 'all').mockReturnValue({
         reduction: [{ reduction: 'PAY THE PRICE', weight: 0.1 }],

--- a/server/apps/backend/src/services/dispatcher/Dispatcher.ts
+++ b/server/apps/backend/src/services/dispatcher/Dispatcher.ts
@@ -131,7 +131,7 @@ class Dispatcher {
       if (this.isWeightedReduction(reductionStrategy)) {
         reductionStrategy = this.getWeightedReduction(reductionStrategy);
       }
-      return _.sample(reductionStrategy);
+      reductionStrategy = _.sample(reductionStrategy);
     }
     return reductionStrategy;
   }

--- a/server/apps/backend/src/services/dispatcher/Dispatcher.ts
+++ b/server/apps/backend/src/services/dispatcher/Dispatcher.ts
@@ -101,6 +101,27 @@ class Dispatcher {
     return nextIteration;
   }
 
+  public getReductionStrategy(): string | undefined {
+    let reductionStrategy = this.getConfiguration(this).reduction;
+    if (Array.isArray(reductionStrategy)) {
+      if (this.isWeightedReduction(reductionStrategy)) {
+        reductionStrategy = this.getWeightedReduction(reductionStrategy);
+      }
+      reductionStrategy = _.sample(reductionStrategy);
+    }
+    return reductionStrategy;
+  }
+
+  public getWeightedReduction(
+    reductionStrategy: WeightedReduction[]
+  ): string[] {
+    return reductionStrategy
+      .map((strategy) =>
+        Array(Math.ceil(strategy.weight * 100)).fill(strategy.reduction)
+      )
+      .flat();
+  }
+
   private putSellerOffline(
     self: Dispatcher,
     seller: Seller,
@@ -125,33 +146,12 @@ class Dispatcher {
     };
   }
 
-  private getReductionStrategy(): string | undefined {
-    let reductionStrategy = this.getConfiguration(this).reduction;
-    if (Array.isArray(reductionStrategy)) {
-      if (this.isWeightedReduction(reductionStrategy)) {
-        reductionStrategy = this.getWeightedReduction(reductionStrategy);
-      }
-      reductionStrategy = _.sample(reductionStrategy);
-    }
-    return reductionStrategy;
-  }
-
   private isWeightedReduction(
     reduction: string[] | WeightedReduction[]
   ): reduction is WeightedReduction[] {
     return (reduction as WeightedReduction[]).every(
       (strategy) => strategy.weight !== undefined
     );
-  }
-
-  private getWeightedReduction(
-    reductionStrategy: WeightedReduction[]
-  ): string[] {
-    return reductionStrategy
-      .map((strategy) =>
-        Array(Math.ceil(strategy.weight * 100)).fill(strategy.reduction)
-      )
-      .flat();
   }
 
   private getReductionPeriodFor(reductionStrategy?: string): Period {

--- a/server/apps/backend/src/services/dispatcher/Dispatcher.ts
+++ b/server/apps/backend/src/services/dispatcher/Dispatcher.ts
@@ -126,10 +126,10 @@ class Dispatcher {
   }
 
   private getReductionStrategy(): string | undefined {
-    const reductionStrategy = this.getConfiguration(this).reduction;
+    let reductionStrategy = this.getConfiguration(this).reduction;
     if (Array.isArray(reductionStrategy)) {
       if (this.isWeightedReduction(reductionStrategy)) {
-        return this.getWeightedReduction(reductionStrategy);
+        reductionStrategy = this.getWeightedReduction(reductionStrategy);
       }
       return _.sample(reductionStrategy);
     }
@@ -144,13 +144,14 @@ class Dispatcher {
     );
   }
 
-  private getWeightedReduction(reductionStrategy: WeightedReduction[]): string {
-    const weightedReductionStrat = reductionStrategy
+  private getWeightedReduction(
+    reductionStrategy: WeightedReduction[]
+  ): string[] {
+    return reductionStrategy
       .map((strategy) =>
         Array(Math.ceil(strategy.weight * 100)).fill(strategy.reduction)
       )
       .flat();
-    return _.sample(weightedReductionStrat);
   }
 
   private getReductionPeriodFor(reductionStrategy?: string): Period {

--- a/server/apps/backend/src/services/dispatcher/Dispatcher.ts
+++ b/server/apps/backend/src/services/dispatcher/Dispatcher.ts
@@ -1,6 +1,6 @@
 import colors from 'colors';
 import _ from 'lodash';
-import Configuration from '../../config';
+import Configuration, { WeightedReduction } from '../../config';
 import logger from '../../logger';
 import { Seller } from '../../repositories';
 import utils from '../../utils';
@@ -128,9 +128,29 @@ class Dispatcher {
   private getReductionStrategy(): string | undefined {
     const reductionStrategy = this.getConfiguration(this).reduction;
     if (Array.isArray(reductionStrategy)) {
+      if (this.isWeightedReduction(reductionStrategy)) {
+        return this.getWeightedReduction(reductionStrategy);
+      }
       return _.sample(reductionStrategy);
     }
     return reductionStrategy;
+  }
+
+  private isWeightedReduction(
+    reduction: string[] | WeightedReduction[]
+  ): reduction is WeightedReduction[] {
+    return (reduction as WeightedReduction[]).every(
+      (strategy) => strategy.weight !== undefined
+    );
+  }
+
+  private getWeightedReduction(reductionStrategy: WeightedReduction[]): string {
+    const weightedReductionStrat = reductionStrategy
+      .map((strategy) =>
+        Array(Math.ceil(strategy.weight * 100)).fill(strategy.reduction)
+      )
+      .flat();
+    return _.sample(weightedReductionStrat);
   }
 
   private getReductionPeriodFor(reductionStrategy?: string): Period {


### PR DESCRIPTION
As discussed in #7 , on top of having the option to use a list of reductions, it would be nice also to be able to add a weight to each option.

This is an attempt to do so.

Of the many possible algorithms to randomly select an item in a weighted list, this is the most simple - but also the less performant. However, given that we only use up to three elements in our original array, I believe this is more than good enough for this usecase. If you don't like it, I can implement another algorithm instead.

I added a typeguard following the [official doc](https://www.typescriptlang.org/docs/handbook/advanced-types.html), to check if what we're passing is a `WeightedReduction`.

Because it's hard to write a test for these random selections (also without testing the implementation itself), I've tested manually, and the reductions used seemed consistent with the different weights provided.

Some of these concepts are new to me, so again, I'm open to feedback. Also if I should move some things around, etc.