### PR TITLE
refactor: move logic embeded in router to dedicated controller

### DIFF
--- a/server/apps/backend/package.json
+++ b/server/apps/backend/package.json
@@ -23,6 +23,7 @@
     "cross-env": "7.0.3",
     "express": "4.18.2",
     "http-status-codes": "2.2.0",
+    "joi": "17.7.0",
     "lodash": "4.17.21",
     "winston": "3.8.2"
   },

--- a/server/apps/backend/package.json
+++ b/server/apps/backend/package.json
@@ -18,14 +18,12 @@
     "@types/express": "4.17.14",
     "@types/http-status-codes": "1.2.0",
     "@types/lodash": "4.14.189",
-    "@types/url-assembler": "2.1.1",
     "body-parser": "1.20.1",
     "colors": "1.4.0",
     "cross-env": "7.0.3",
     "express": "4.18.2",
     "http-status-codes": "2.2.0",
     "lodash": "4.17.21",
-    "url-assembler": "2.1.1",
     "winston": "3.8.2"
   },
   "devDependencies": {

--- a/server/apps/backend/package.json
+++ b/server/apps/backend/package.json
@@ -16,12 +16,14 @@
   "dependencies": {
     "@types/body-parser": "1.19.2",
     "@types/express": "4.17.14",
+    "@types/http-status-codes": "1.2.0",
     "@types/lodash": "4.14.189",
     "@types/url-assembler": "2.1.1",
     "body-parser": "1.20.1",
     "colors": "1.4.0",
     "cross-env": "7.0.3",
     "express": "4.18.2",
+    "http-status-codes": "2.2.0",
     "lodash": "4.17.21",
     "url-assembler": "2.1.1",
     "winston": "3.8.2"
@@ -31,6 +33,7 @@
     "@swc/jest": "0.2.23",
     "@tsconfig/node16": "1.0.3",
     "@types/jest": "29.2.3",
+    "@types/jest-when": "3.5.2",
     "@types/node": "18.11.9",
     "@types/supertest": "2.0.12",
     "@typescript-eslint/eslint-plugin": "5.43.0",
@@ -42,6 +45,8 @@
     "eslint-config-prettier": "8.5.0",
     "eslint-plugin-import": "2.26.0",
     "jest": "29.3.1",
+    "jest-when": "3.5.2",
+    "node-mocks-http": "1.12.1",
     "supertest": "6.3.1",
     "tsup": "6.5.0",
     "typescript": "4.8.4"

--- a/server/apps/backend/src/SellerController.spec.ts
+++ b/server/apps/backend/src/SellerController.spec.ts
@@ -1,0 +1,237 @@
+import { Request, Response } from 'express-serve-static-core';
+import { StatusCodes } from 'http-status-codes';
+import { when } from 'jest-when';
+import httpMocks, { MockRequest, MockResponse } from 'node-mocks-http';
+import UrlAssembler from 'url-assembler';
+import Configuration from './config';
+import { Sellers } from './repositories';
+import {
+  listSellers,
+  registerSeller,
+  sellersHistory,
+} from './SellerController';
+import { SellerService } from './services';
+
+describe('Seller Controller', () => {
+  let sellerService: SellerService;
+
+  beforeEach(() => {
+    sellerService = new SellerService(new Sellers(), new Configuration());
+  });
+
+  describe('listSellers', () => {
+    it('should return only seller name, cash and online status', () => {
+      const request = httpMocks.createRequest({});
+      const response = httpMocks.createResponse();
+
+      jest.spyOn(sellerService, 'allSellers').mockReturnValue([
+        {
+          name: 'John',
+          cash: 123,
+          online: true,
+          hostname: 'http://localhost',
+          path: '',
+          password: 'password',
+          url: new UrlAssembler('http://localhost'),
+          port: '8080',
+        },
+      ]);
+
+      listSellers(sellerService)(request, response);
+
+      expect(response._getData()).toEqual([
+        {
+          name: 'John',
+          cash: 123,
+          online: true,
+        },
+      ]);
+    });
+  });
+
+  describe('sellersHistory', () => {
+    const CASH_HISTORY = {
+      history: {
+        John: [1, 2, 3],
+      },
+      lastIteration: 3,
+    };
+
+    describe('when chunk is present in query and is a string', () => {
+      it('should call getCashHistory with specified chunk', () => {
+        const request = httpMocks.createRequest({
+          query: {
+            chunk: '42',
+          },
+        });
+        const response = httpMocks.createResponse();
+        when(jest.spyOn(sellerService, 'getCashHistory'))
+          .calledWith(42)
+          .mockReturnValue(CASH_HISTORY);
+
+        sellersHistory(sellerService)(request, response);
+
+        expect(response._getData()).toEqual(CASH_HISTORY);
+      });
+    });
+
+    describe('when chunk is present in query but is not a string', () => {
+      it('should call getCashHistory with default chunk', () => {
+        const request = httpMocks.createRequest({
+          query: {
+            chunk: { foo: 'bar' },
+          },
+        });
+        const response = httpMocks.createResponse();
+        when(jest.spyOn(sellerService, 'getCashHistory'))
+          .calledWith(10)
+          .mockReturnValue(CASH_HISTORY);
+
+        sellersHistory(sellerService)(request, response);
+
+        expect(response._getData()).toEqual(CASH_HISTORY);
+      });
+    });
+
+    describe('when chunk is not present in query', () => {
+      it('should call getCashHistory with default chunk', () => {
+        const request = httpMocks.createRequest({
+          query: {},
+        });
+        const response = httpMocks.createResponse();
+        when(jest.spyOn(sellerService, 'getCashHistory'))
+          .calledWith(10)
+          .mockReturnValue(CASH_HISTORY);
+
+        sellersHistory(sellerService)(request, response);
+
+        expect(response._getData()).toEqual(CASH_HISTORY);
+      });
+    });
+  });
+
+  describe('registerSeller', () => {
+    let request: MockRequest<Request>;
+    let response: MockResponse<Response>;
+    const SELLER = {
+      name: 'John',
+      password: 'password',
+      url: 'http://localhost:3000',
+    };
+    const registerMock = jest.fn();
+
+    beforeEach(() => {
+      response = httpMocks.createResponse();
+      jest.spyOn(sellerService, 'register').mockImplementation(registerMock);
+    });
+
+    describe('when body has no name', () => {
+      it('should return a bad request', () => {
+        const { name, ...bodyWithoutName } = SELLER;
+        request = httpMocks.createRequest({
+          body: bodyWithoutName,
+        });
+
+        registerSeller(sellerService)(request, response);
+
+        expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST);
+        expect(registerMock).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when body has no password', () => {
+      it('should return a bad request', () => {
+        const { password, ...bodyWithoutPassword } = SELLER;
+        request = httpMocks.createRequest({
+          body: bodyWithoutPassword,
+        });
+
+        registerSeller(sellerService)(request, response);
+
+        expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST);
+        expect(registerMock).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when body has no url', () => {
+      it('should return a bad request', () => {
+        const { url, ...bodyWithoutUrl } = SELLER;
+        request = httpMocks.createRequest({
+          body: bodyWithoutUrl,
+        });
+
+        registerSeller(sellerService)(request, response);
+
+        expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST);
+        expect(registerMock).not.toHaveBeenCalled();
+      });
+    });
+
+    describe.each([
+      ['missing protocol', 'localhost'],
+      ['invalid protocol', 'foo://localhost'],
+    ])('when body has all required fields but invalid url (%s)', (_, url) => {
+      it('should return a bad request', () => {
+        request = httpMocks.createRequest({
+          body: {
+            ...SELLER,
+            url,
+          },
+        });
+
+        registerSeller(sellerService)(request, response);
+
+        expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST);
+        expect(registerMock).not.toHaveBeenCalled();
+      });
+    });
+
+    describe.each([
+      ['http', 'http://localhost'],
+      ['https', 'https://localhost'],
+    ])('when body has all required fields but and valid url (%s)', (_, url) => {
+      beforeEach(() => {
+        request = httpMocks.createRequest({
+          body: {
+            ...SELLER,
+            url,
+          },
+        });
+      });
+
+      describe('when seller is not authorized', () => {
+        beforeEach(() => {
+          when(jest.spyOn(sellerService, 'isAuthorized'))
+            .calledWith(SELLER.name, SELLER.password)
+            .mockReturnValue(false);
+        });
+
+        it('should return a unauthorized', () => {
+          registerSeller(sellerService)(request, response);
+
+          expect(registerMock).not.toHaveBeenCalled();
+          expect(response.statusCode).toBe(StatusCodes.UNAUTHORIZED);
+        });
+      });
+
+      describe('when seller is authorized', () => {
+        beforeEach(() => {
+          when(jest.spyOn(sellerService, 'isAuthorized'))
+            .calledWith(SELLER.name, SELLER.password)
+            .mockReturnValue(true);
+        });
+
+        it('should return a success', () => {
+          registerSeller(sellerService)(request, response);
+
+          expect(registerMock).toHaveBeenCalledWith(
+            url,
+            SELLER.name,
+            SELLER.password
+          );
+          expect(response.statusCode).toBe(StatusCodes.OK);
+        });
+      });
+    });
+  });
+});

--- a/server/apps/backend/src/SellerController.spec.ts
+++ b/server/apps/backend/src/SellerController.spec.ts
@@ -2,7 +2,6 @@ import { Request, Response } from 'express-serve-static-core';
 import { StatusCodes } from 'http-status-codes';
 import { when } from 'jest-when';
 import httpMocks, { MockRequest, MockResponse } from 'node-mocks-http';
-import UrlAssembler from 'url-assembler';
 import Configuration from './config';
 import { Sellers } from './repositories';
 import {
@@ -32,7 +31,6 @@ describe('Seller Controller', () => {
           hostname: 'http://localhost',
           path: '',
           password: 'password',
-          url: new UrlAssembler('http://localhost'),
           port: '8080',
         },
       ]);

--- a/server/apps/backend/src/SellerController.ts
+++ b/server/apps/backend/src/SellerController.ts
@@ -1,0 +1,47 @@
+import { Request, Response } from 'express-serve-static-core';
+import { SellerService } from './services';
+
+const OK = 200;
+const BAD_REQUEST = 400;
+const UNAUTHORIZED = 401;
+
+export const listSellers =
+  (sellerService: SellerService) => (_: Request, response: Response) => {
+    const sellerViews = sellerService.allSellers().map((seller) => ({
+      cash: seller.cash,
+      name: seller.name,
+      online: seller.online,
+    }));
+    response.status(OK).send(sellerViews);
+  };
+
+export const sellersHistory =
+  (sellerService: SellerService) => (request: Request, response: Response) => {
+    let chunk: number;
+    if (request.query.chunk && typeof request.query.chunk === 'string') {
+      chunk = parseInt(request.query.chunk, 10);
+    } else {
+      chunk = 10;
+    }
+    response.status(OK).send(sellerService.getCashHistory(chunk));
+  };
+
+export const registerSeller =
+  (sellerService: SellerService) => (request: Request, response: Response) => {
+    const sellerName = request.body.name;
+    const sellerUrl = request.body.url;
+    const sellerPwd = request.body.password;
+
+    if (!sellerName || !sellerUrl || !sellerPwd) {
+      response
+        .status(BAD_REQUEST)
+        .send({ message: 'missing name, password or url' });
+    } else if (sellerService.isAuthorized(sellerName, sellerPwd)) {
+      sellerService.register(sellerUrl, sellerName, sellerPwd);
+      response.status(OK).end();
+    } else {
+      response
+        .status(UNAUTHORIZED)
+        .send({ message: 'invalid name or password' });
+    }
+  };

--- a/server/apps/backend/src/SellerController.ts
+++ b/server/apps/backend/src/SellerController.ts
@@ -24,11 +24,12 @@ export const sellersHistory =
     response.status(StatusCodes.OK).send(sellerService.getCashHistory(chunk));
   };
 
-type RegisterSellerRequest = {
-  name: string;
-  password: string;
-  url: string;
+export type MaybeRegisterSellerRequest = {
+  name?: string;
+  password?: string;
+  url?: string;
 };
+export type RegisterSellerRequest = Required<MaybeRegisterSellerRequest>;
 const registerSellerValidator = Joi.object<RegisterSellerRequest>({
   name: Joi.string().required(),
   password: Joi.string().required(),

--- a/server/apps/backend/src/SellerController.ts
+++ b/server/apps/backend/src/SellerController.ts
@@ -1,9 +1,7 @@
 import { Request, Response } from 'express-serve-static-core';
+import { StatusCodes } from 'http-status-codes';
 import { SellerService } from './services';
-
-const OK = 200;
-const BAD_REQUEST = 400;
-const UNAUTHORIZED = 401;
+import { isValidUrl } from './utils';
 
 export const listSellers =
   (sellerService: SellerService) => (_: Request, response: Response) => {
@@ -12,7 +10,7 @@ export const listSellers =
       name: seller.name,
       online: seller.online,
     }));
-    response.status(OK).send(sellerViews);
+    response.status(StatusCodes.OK).send(sellerViews);
   };
 
 export const sellersHistory =
@@ -23,25 +21,27 @@ export const sellersHistory =
     } else {
       chunk = 10;
     }
-    response.status(OK).send(sellerService.getCashHistory(chunk));
+    response.status(StatusCodes.OK).send(sellerService.getCashHistory(chunk));
   };
 
 export const registerSeller =
   (sellerService: SellerService) => (request: Request, response: Response) => {
-    const sellerName = request.body.name;
-    const sellerUrl = request.body.url;
-    const sellerPwd = request.body.password;
+    const {
+      name: sellerName,
+      url: sellerUrl,
+      password: sellerPwd,
+    } = request.body;
 
-    if (!sellerName || !sellerUrl || !sellerPwd) {
+    if (!sellerName || !sellerUrl || !sellerPwd || !isValidUrl(sellerUrl)) {
       response
-        .status(BAD_REQUEST)
+        .status(StatusCodes.BAD_REQUEST)
         .send({ message: 'missing name, password or url' });
     } else if (sellerService.isAuthorized(sellerName, sellerPwd)) {
       sellerService.register(sellerUrl, sellerName, sellerPwd);
-      response.status(OK).end();
+      response.status(StatusCodes.OK).end();
     } else {
       response
-        .status(UNAUTHORIZED)
+        .status(StatusCodes.UNAUTHORIZED)
         .send({ message: 'invalid name or password' });
     }
   };

--- a/server/apps/backend/src/SellerController.ts
+++ b/server/apps/backend/src/SellerController.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express-serve-static-core';
 import { StatusCodes } from 'http-status-codes';
+import Joi from 'joi';
 import { SellerService } from './services';
 import { isValidUrl } from './utils';
 
@@ -13,30 +14,43 @@ export const listSellers =
     response.status(StatusCodes.OK).send(sellerViews);
   };
 
+const sellersHistoryValidator = Joi.number().required();
 export const sellersHistory =
   (sellerService: SellerService) => (request: Request, response: Response) => {
-    let chunk: number;
-    if (request.query.chunk && typeof request.query.chunk === 'string') {
-      chunk = parseInt(request.query.chunk, 10);
-    } else {
-      chunk = 10;
-    }
+    const { error, value } = sellersHistoryValidator.validate(
+      request.query.chunk
+    );
+    const chunk = !error ? value : 10;
     response.status(StatusCodes.OK).send(sellerService.getCashHistory(chunk));
   };
 
+type RegisterSellerRequest = {
+  name: string;
+  password: string;
+  url: string;
+};
+const registerSellerValidator = Joi.object<RegisterSellerRequest>({
+  name: Joi.string().required(),
+  password: Joi.string().required(),
+  url: Joi.custom((value) => {
+    if (!isValidUrl(value)) {
+      throw new Error('invalid URL');
+    }
+    return value;
+  }).required(),
+});
 export const registerSeller =
   (sellerService: SellerService) => (request: Request, response: Response) => {
-    const {
-      name: sellerName,
-      url: sellerUrl,
-      password: sellerPwd,
-    } = request.body;
-
-    if (!sellerName || !sellerUrl || !sellerPwd || !isValidUrl(sellerUrl)) {
+    const { error, value } = registerSellerValidator.validate(request.body);
+    if (error) {
       response
         .status(StatusCodes.BAD_REQUEST)
         .send({ message: 'missing name, password or url' });
-    } else if (sellerService.isAuthorized(sellerName, sellerPwd)) {
+      return;
+    }
+
+    const { name: sellerName, url: sellerUrl, password: sellerPwd } = value;
+    if (sellerService.isAuthorized(sellerName, sellerPwd)) {
       sellerService.register(sellerUrl, sellerName, sellerPwd);
       response.status(StatusCodes.OK).end();
     } else {

--- a/server/apps/backend/src/error-utils.ts
+++ b/server/apps/backend/src/error-utils.ts
@@ -1,3 +1,5 @@
+import { ValidationError } from 'joi';
+
 const hasMessage = (error: unknown): error is Error => {
   if (typeof error === 'object' && error) {
     return 'message' in error;
@@ -7,3 +9,6 @@ const hasMessage = (error: unknown): error is Error => {
 
 export const messageFromError = (error: unknown): string =>
   hasMessage(error) ? error.message : 'Unknown error';
+
+export const messageFromValidationError = (error: ValidationError): string =>
+  error.details.map((it) => it.message).join(', ');

--- a/server/apps/backend/src/fixtures/index.ts
+++ b/server/apps/backend/src/fixtures/index.ts
@@ -1,0 +1,8 @@
+export { cashHistory, seller1, seller2, sellers } from './sellers.fixture';
+export {
+  missingNameSellerRequest,
+  missingPasswordSellerRequest,
+  missingUrlSellerRequest,
+  validSellerRequest,
+  validSellerRequestWithUrl,
+} from './registerSeller.fixture';

--- a/server/apps/backend/src/fixtures/registerSeller.fixture.ts
+++ b/server/apps/backend/src/fixtures/registerSeller.fixture.ts
@@ -1,0 +1,33 @@
+import {
+  MaybeRegisterSellerRequest,
+  RegisterSellerRequest,
+} from '../SellerController';
+
+export const validSellerRequest: RegisterSellerRequest = {
+  name: 'John',
+  password: '12345',
+  url: 'http://192.168.0.1',
+};
+
+export const validSellerRequestWithUrl = (
+  url: string
+): MaybeRegisterSellerRequest => ({
+  name: 'John',
+  password: '12345',
+  url,
+});
+
+export const missingNameSellerRequest: MaybeRegisterSellerRequest = {
+  ...validSellerRequest,
+  name: undefined,
+};
+
+export const missingPasswordSellerRequest: MaybeRegisterSellerRequest = {
+  ...validSellerRequest,
+  password: undefined,
+};
+
+export const missingUrlSellerRequest: MaybeRegisterSellerRequest = {
+  ...validSellerRequest,
+  url: undefined,
+};

--- a/server/apps/backend/src/fixtures/sellers.fixture.ts
+++ b/server/apps/backend/src/fixtures/sellers.fixture.ts
@@ -1,0 +1,32 @@
+import { Seller } from '../repositories';
+import { CashHistory } from '../services/SellerService';
+
+export const seller1: Seller = {
+  name: 'John',
+  cash: 1000,
+  online: true,
+  hostname: 'http://192.168.0.1',
+  path: '',
+  password: '12345',
+  port: '8080',
+};
+
+export const seller2: Seller = {
+  name: 'Alex',
+  cash: 1500,
+  online: false,
+  hostname: 'https://192.168.0.2',
+  path: '',
+  password: '12345',
+  port: '8080',
+};
+
+export const sellers = [seller1, seller2];
+
+export const cashHistory: CashHistory = {
+  history: {
+    John: [0, 0, 500, 1000],
+    Alex: [0, 500, 1000, 1500],
+  },
+  lastIteration: 4,
+};

--- a/server/apps/backend/src/repositories/Seller.ts
+++ b/server/apps/backend/src/repositories/Seller.ts
@@ -1,5 +1,3 @@
-import UrlAssembler from 'url-assembler';
-
 export type Seller = {
   name: string;
   password?: string;
@@ -8,7 +6,6 @@ export type Seller = {
   path?: string;
   cash: number;
   online?: boolean;
-  url?: UrlAssembler;
 };
 
 export const buildWithDefaults = (values: Partial<Seller>) => ({
@@ -19,6 +16,5 @@ export const buildWithDefaults = (values: Partial<Seller>) => ({
   path: '/',
   cash: 0,
   online: true,
-  url: new UrlAssembler(),
   ...values,
 });

--- a/server/apps/backend/src/routes.ts
+++ b/server/apps/backend/src/routes.ts
@@ -1,50 +1,19 @@
 import express from 'express';
+import {
+  listSellers,
+  registerSeller,
+  sellersHistory,
+} from './SellerController';
 import { SellerService } from './services';
 
 const routes = (sellerService: SellerService) => {
   const router = express.Router();
-  const OK = 200;
-  const BAD_REQUEST = 400;
-  const UNAUTHORIZED = 401;
 
-  router.get('/sellers', (_request, response) => {
-    // seller view is returned, to prevent any confidential information leaks
-    const sellerViews = sellerService.allSellers().map((seller) => ({
-      cash: seller.cash,
-      name: seller.name,
-      online: seller.online,
-    }));
-    response.status(OK).send(sellerViews);
-  });
+  router.get('/sellers', listSellers(sellerService));
 
-  router.get('/sellers/history', (request, response) => {
-    let chunk: number;
-    if (request.query.chunk && typeof request.query.chunk === 'string') {
-      chunk = parseInt(request.query.chunk, 10);
-    } else {
-      chunk = 10;
-    }
-    response.status(OK).send(sellerService.getCashHistory(chunk));
-  });
+  router.get('/sellers/history', sellersHistory(sellerService));
 
-  router.post('/seller', (request, response) => {
-    const sellerName = request.body.name;
-    const sellerUrl = request.body.url;
-    const sellerPwd = request.body.password;
-
-    if (!sellerName || !sellerUrl || !sellerPwd) {
-      response
-        .status(BAD_REQUEST)
-        .send({ message: 'missing name, password or url' });
-    } else if (sellerService.isAuthorized(sellerName, sellerPwd)) {
-      sellerService.register(sellerUrl, sellerName, sellerPwd);
-      response.status(OK).end();
-    } else {
-      response
-        .status(UNAUTHORIZED)
-        .send({ message: 'invalid name or password' });
-    }
-  });
+  router.post('/seller', registerSeller(sellerService));
 
   return router;
 };

--- a/server/apps/backend/src/services/SellerService.spec.ts
+++ b/server/apps/backend/src/services/SellerService.spec.ts
@@ -1,4 +1,3 @@
-import UrlAssembler from 'url-assembler';
 import Configuration, { Settings } from '../config';
 import { Seller, Sellers } from '../repositories';
 import { buildWithDefaults } from '../repositories/Seller';
@@ -39,8 +38,6 @@ describe('Seller Service', () => {
     expect(actual?.name).toBe('bob');
     expect(actual?.cash).toBe(0);
     expect(actual?.online).toBe(false);
-    expect(actual?.url instanceof UrlAssembler).toBeTruthy();
-    expect(actual?.url?.toString()).toBe('http://localhost:3000/path');
   });
 
   it('should register new seller with an empty path', () => {
@@ -52,8 +49,6 @@ describe('Seller Service', () => {
     expect(actual?.cash).toBe(0);
     expect(actual?.online).toBe(false);
     expect(actual?.path).toBe('/');
-    expect(actual?.url instanceof UrlAssembler).toBeTruthy();
-    expect(actual?.url?.toString()).toBe('http://localhost:3000');
   });
 
   it("should compute seller's cash based on the order's amount", () => {

--- a/server/apps/backend/src/services/SellerService.ts
+++ b/server/apps/backend/src/services/SellerService.ts
@@ -1,6 +1,5 @@
 import url from 'node:url';
 import _ from 'lodash';
-import UrlAssembler from 'url-assembler';
 import Configuration from '../config';
 import { messageFromError } from '../error-utils';
 import logger from '../logger';
@@ -75,7 +74,6 @@ export default class SellerService {
       path: parsedUrl.pathname,
       cash: 0.0,
       online: false,
-      url: new UrlAssembler(sellerUrl),
     };
     this.sellers.save(seller);
     logger.info(`New seller registered: ${utils.stringify(seller)}`);

--- a/server/apps/backend/src/services/SellerService.ts
+++ b/server/apps/backend/src/services/SellerService.ts
@@ -8,6 +8,10 @@ import { Seller, Sellers } from '../repositories';
 import utils from '../utils';
 import { Bill } from './Bill';
 
+export type CashHistory = {
+  history: Record<string, number[]>;
+  lastIteration: number;
+}
 type Message = {
   type: 'ERROR' | 'INFO';
   content: string;
@@ -18,18 +22,18 @@ export default class SellerService {
     private readonly configuration: Configuration
   ) {}
 
-  public addCash(seller: Seller, amount: number, currentIteration: number) {
+  public addCash(seller: Seller, amount: number, currentIteration: number): void {
     this.sellers.updateCash(seller.name, amount, currentIteration);
   }
 
-  public deductCash(seller: Seller, amount: number, currentIteration: number) {
+  public deductCash(seller: Seller, amount: number, currentIteration: number): void {
     this.sellers.updateCash(seller.name, -amount, currentIteration);
   }
 
-  public getCashHistory(chunk: number) {
+  public getCashHistory(chunk: number): CashHistory {
     const { cashHistory } = this.sellers;
     const cashHistoryReduced: Record<string, number[]> = {};
-    let lastIteration;
+    let lastIteration: number = 0;
 
     Object.keys(cashHistory).forEach((seller) => {
       cashHistoryReduced[seller] = [];
@@ -51,7 +55,7 @@ export default class SellerService {
     return { history: cashHistoryReduced, lastIteration };
   }
 
-  public isAuthorized(name: string, password: string) {
+  public isAuthorized(name: string, password: string): boolean {
     const seller = this.sellers.get(name);
     if (seller) {
       const samePwd = seller.password === password;
@@ -61,7 +65,7 @@ export default class SellerService {
     return true;
   }
 
-  public register(sellerUrl: string, name: string, password?: string) {
+  public register(sellerUrl: string, name: string, password?: string): void {
     const parsedUrl = new url.URL(sellerUrl);
     const seller: Seller = {
       name,
@@ -77,7 +81,7 @@ export default class SellerService {
     logger.info(`New seller registered: ${utils.stringify(seller)}`);
   }
 
-  public allSellers() {
+  public allSellers(): Seller[] {
     return this.sellers.all();
   }
 
@@ -86,7 +90,7 @@ export default class SellerService {
     expectedBill: Bill,
     actualBill: Bill | undefined,
     currentIteration: number
-  ) {
+  ): void {
     if (this.configuration.all().cashFreeze) {
       logger.info(
         'Cash was not updated because cashFreeze config parameter is true'
@@ -127,7 +131,7 @@ export default class SellerService {
     }
   }
 
-  public notify(seller: Seller, message: Message) {
+  public notify(seller: Seller, message: Message): void {
     utils.post(
       seller.hostname,
       seller.port,
@@ -146,7 +150,7 @@ export default class SellerService {
     seller: Seller,
     offlinePenalty: number,
     currentIteration: number
-  ) {
+  ): void {
     this.sellers.setOffline(seller.name);
 
     if (offlinePenalty !== 0) {
@@ -157,7 +161,7 @@ export default class SellerService {
     }
   }
 
-  public setOnline(seller: Seller) {
+  public setOnline(seller: Seller): void {
     this.sellers.setOnline(seller.name);
   }
 }

--- a/server/apps/backend/src/services/SellerService.ts
+++ b/server/apps/backend/src/services/SellerService.ts
@@ -8,9 +8,9 @@ import utils from '../utils';
 import { Bill } from './Bill';
 
 export type CashHistory = {
-  history: Record<string, number[]>;
+  history: Record<Seller['name'], Seller['cash'][]>;
   lastIteration: number;
-}
+};
 type Message = {
   type: 'ERROR' | 'INFO';
   content: string;
@@ -21,11 +21,19 @@ export default class SellerService {
     private readonly configuration: Configuration
   ) {}
 
-  public addCash(seller: Seller, amount: number, currentIteration: number): void {
+  public addCash(
+    seller: Seller,
+    amount: number,
+    currentIteration: number
+  ): void {
     this.sellers.updateCash(seller.name, amount, currentIteration);
   }
 
-  public deductCash(seller: Seller, amount: number, currentIteration: number): void {
+  public deductCash(
+    seller: Seller,
+    amount: number,
+    currentIteration: number
+  ): void {
     this.sellers.updateCash(seller.name, -amount, currentIteration);
   }
 

--- a/server/apps/backend/src/utils.spec.ts
+++ b/server/apps/backend/src/utils.spec.ts
@@ -53,8 +53,8 @@ describe('Utils', () => {
 
   describe('isValidUrl', () => {
     describe.each([
-        ['missing protocol', 'localhost'],
-        ['invalid protocol', 'foo://localhost'],
+      ['missing protocol', 'localhost'],
+      ['invalid protocol', 'foo://localhost'],
     ])('when url is %s', (_, url) => {
       it('should return false', () => {
         expect(isValidUrl(url)).toBe(false);
@@ -67,6 +67,7 @@ describe('Utils', () => {
       ['url with port', 'https://localhost:3000'],
       ['url with path', 'https://localhost/path'],
       ['url with port and path', 'https://localhost:3000/path'],
+      ['IP with port and path', 'https://192.168.0.0:3000/path'],
     ])('when url is %s', (_, url) => {
       it('should return true', () => {
         expect(isValidUrl(url)).toBe(true);

--- a/server/apps/backend/src/utils.spec.ts
+++ b/server/apps/backend/src/utils.spec.ts
@@ -1,5 +1,5 @@
 import http, { ClientRequest } from 'node:http';
-import utils from './utils';
+import utils, { isValidUrl } from './utils';
 
 describe('Utils', () => {
   it('should fix precision for numbers', () => {
@@ -49,5 +49,28 @@ describe('Utils', () => {
     );
     expect(fakeRequest.write).toHaveBeenCalledWith(bodyStringified);
     expect(fakeRequest.end).toHaveBeenCalled();
+  });
+
+  describe('isValidUrl', () => {
+    describe.each([
+        ['missing protocol', 'localhost'],
+        ['invalid protocol', 'foo://localhost'],
+    ])('when url is %s', (_, url) => {
+      it('should return false', () => {
+        expect(isValidUrl(url)).toBe(false);
+      });
+    });
+
+    describe.each([
+      ['http protocol', 'http://localhost'],
+      ['https protocol', 'https://localhost'],
+      ['url with port', 'https://localhost:3000'],
+      ['url with path', 'https://localhost/path'],
+      ['url with port and path', 'https://localhost:3000/path'],
+    ])('when url is %s', (_, url) => {
+      it('should return true', () => {
+        expect(isValidUrl(url)).toBe(true);
+      });
+    });
   });
 });

--- a/server/apps/backend/src/utils.ts
+++ b/server/apps/backend/src/utils.ts
@@ -1,4 +1,5 @@
 import http, { IncomingMessage } from 'node:http';
+import url from "node:url";
 
 class Utils {
   public stringify(value: any) {
@@ -45,6 +46,15 @@ class Utils {
     request.on('error', onError || (() => {}));
     request.write(bodyStringified);
     request.end();
+  }
+}
+
+export const isValidUrl = (value: string): boolean => {
+  try {
+    const validUrl = new url.URL(value);
+    return validUrl.protocol === 'http:' || validUrl.protocol === 'https:';
+  } catch {
+    return false;
   }
 }
 

--- a/server/apps/backend/src/utils.ts
+++ b/server/apps/backend/src/utils.ts
@@ -1,5 +1,5 @@
 import http, { IncomingMessage } from 'node:http';
-import url from "node:url";
+import url from 'node:url';
 
 class Utils {
   public stringify(value: any) {
@@ -56,6 +56,6 @@ export const isValidUrl = (value: string): boolean => {
   } catch {
     return false;
   }
-}
+};
 
 export default new Utils();

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -23,14 +23,12 @@
         "@types/express": "4.17.14",
         "@types/http-status-codes": "1.2.0",
         "@types/lodash": "4.14.189",
-        "@types/url-assembler": "2.1.1",
         "body-parser": "1.20.1",
         "colors": "1.4.0",
         "cross-env": "7.0.3",
         "express": "4.18.2",
         "http-status-codes": "2.2.0",
         "lodash": "4.17.21",
-        "url-assembler": "2.1.1",
         "winston": "3.8.2"
       },
       "devDependencies": {
@@ -1857,13 +1855,6 @@
         "@types/superagent": "*"
       }
     },
-    "node_modules/@types/url-assembler": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/qs": "*"
-      }
-    },
     "node_modules/@types/yargs": {
       "version": "16.0.4",
       "dev": true,
@@ -3552,10 +3543,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-    },
-    "node_modules/extend": {
-      "version": "2.0.2",
-      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -7309,14 +7296,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/url-assembler": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "extend": "^2.0.2",
-        "qs": "^6.5.1"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "license": "MIT"
@@ -8912,12 +8891,6 @@
         "@types/superagent": "*"
       }
     },
-    "@types/url-assembler": {
-      "version": "2.1.1",
-      "requires": {
-        "@types/qs": "*"
-      }
-    },
     "@types/yargs": {
       "version": "16.0.4",
       "dev": true,
@@ -9216,7 +9189,6 @@
         "@types/lodash": "4.14.189",
         "@types/node": "18.11.9",
         "@types/supertest": "2.0.12",
-        "@types/url-assembler": "2.1.1",
         "@typescript-eslint/eslint-plugin": "5.43.0",
         "@typescript-eslint/parser": "5.43.0",
         "body-parser": "1.20.1",
@@ -9237,7 +9209,6 @@
         "supertest": "6.3.1",
         "tsup": "6.5.0",
         "typescript": "4.8.4",
-        "url-assembler": "2.1.1",
         "winston": "3.8.2"
       }
     },
@@ -10076,9 +10047,6 @@
           "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
         }
       }
-    },
-    "extend": {
-      "version": "2.0.2"
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -12622,13 +12590,6 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
-      }
-    },
-    "url-assembler": {
-      "version": "2.1.1",
-      "requires": {
-        "extend": "^2.0.2",
-        "qs": "^6.5.1"
       }
     },
     "util-deprecate": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -28,6 +28,7 @@
         "cross-env": "7.0.3",
         "express": "4.18.2",
         "http-status-codes": "2.2.0",
+        "joi": "17.7.0",
         "lodash": "4.17.21",
         "winston": "3.8.2"
       },
@@ -693,6 +694,19 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+    },
+    "node_modules/@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1406,6 +1420,24 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@sideway/address": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
+      "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+    },
+    "node_modules/@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.24.44",
@@ -5393,6 +5425,18 @@
         "@types/yargs-parser": "*"
       }
     },
+    "node_modules/joi": {
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.7.0.tgz",
+      "integrity": "sha512-1/ugc8djfn93rTE3WRKdCzGGt/EtiYKxITMO4Wiv6q5JL1gl9ePt4kBsl1S499nbosspfctIQTpYIhSmHA3WAg==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.3",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
+      }
+    },
     "node_modules/joycon": {
       "version": "3.1.1",
       "dev": true,
@@ -7991,6 +8035,19 @@
         "strip-json-comments": "^3.1.1"
       }
     },
+    "@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+    },
+    "@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.11.7",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
@@ -8572,6 +8629,24 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@sideway/address": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
+      "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "@sinclair/typebox": {
       "version": "0.24.44",
@@ -9204,6 +9279,7 @@
         "http-status-codes": "2.2.0",
         "jest": "29.3.1",
         "jest-when": "3.5.2",
+        "joi": "17.7.0",
         "lodash": "4.17.21",
         "node-mocks-http": "1.12.1",
         "supertest": "6.3.1",
@@ -11411,6 +11487,18 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "joi": {
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.7.0.tgz",
+      "integrity": "sha512-1/ugc8djfn93rTE3WRKdCzGGt/EtiYKxITMO4Wiv6q5JL1gl9ePt4kBsl1S499nbosspfctIQTpYIhSmHA3WAg==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.3",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
       }
     },
     "joycon": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -21,12 +21,14 @@
       "dependencies": {
         "@types/body-parser": "1.19.2",
         "@types/express": "4.17.14",
+        "@types/http-status-codes": "1.2.0",
         "@types/lodash": "4.14.189",
         "@types/url-assembler": "2.1.1",
         "body-parser": "1.20.1",
         "colors": "1.4.0",
         "cross-env": "7.0.3",
         "express": "4.18.2",
+        "http-status-codes": "2.2.0",
         "lodash": "4.17.21",
         "url-assembler": "2.1.1",
         "winston": "3.8.2"
@@ -36,6 +38,7 @@
         "@swc/jest": "0.2.23",
         "@tsconfig/node16": "1.0.3",
         "@types/jest": "29.2.3",
+        "@types/jest-when": "3.5.2",
         "@types/node": "18.11.9",
         "@types/supertest": "2.0.12",
         "@typescript-eslint/eslint-plugin": "5.43.0",
@@ -47,6 +50,8 @@
         "eslint-config-prettier": "8.5.0",
         "eslint-plugin-import": "2.26.0",
         "jest": "29.3.1",
+        "jest-when": "3.5.2",
+        "node-mocks-http": "1.12.1",
         "supertest": "6.3.1",
         "tsup": "6.5.0",
         "typescript": "4.8.4"
@@ -1728,6 +1733,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/http-status-codes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-status-codes/-/http-status-codes-1.2.0.tgz",
+      "integrity": "sha512-vjpjevMaxtrtdrrV/TQNIFT7mKL8nvIKG7G/LjMDZdVvqRxRg5SNfGkeuSaowVc0rbK8xDA2d/Etunyb5GyzzA==",
+      "deprecated": "This is a stub types definition for http-status-codes (https://github.com/prettymuchbryce/node-http-status). http-status-codes provides its own type definitions, so you don\\'t need @types/http-status-codes installed!",
+      "dependencies": {
+        "http-status-codes": "*"
+      }
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "dev": true,
@@ -1757,6 +1771,15 @@
       "dependencies": {
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
+      }
+    },
+    "node_modules/@types/jest-when": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@types/jest-when/-/jest-when-3.5.2.tgz",
+      "integrity": "sha512-1WP+wJDW7h4TYAVLoIebxRIVv8GPk66Qsq2nU7PkwKZ6usurnDQZgk0DfBNKAJ9gVzapCXSV53Vn/3nBHBNzAw==",
+      "dev": true,
+      "dependencies": {
+        "@types/jest": "*"
       }
     },
     "node_modules/@types/json-schema": {
@@ -4010,6 +4033,11 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/http-status-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+      "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng=="
+    },
     "node_modules/human-signals": {
       "version": "2.1.0",
       "dev": true,
@@ -5313,6 +5341,15 @@
         "@types/yargs-parser": "*"
       }
     },
+    "node_modules/jest-when": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/jest-when/-/jest-when-3.5.2.tgz",
+      "integrity": "sha512-4rDvnhaWh08RcPsoEVXgxRnUIE9wVIbZtGqZ5x2Wm9Ziz9aQs89PipQFmOK0ycbEhVAgiV3MUeTXp3Ar4s2FcQ==",
+      "dev": true,
+      "peerDependencies": {
+        "jest": ">= 25"
+      }
+    },
     "node_modules/jest-worker": {
       "version": "29.3.1",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.3.1.tgz",
@@ -5711,6 +5748,36 @@
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true
+    },
+    "node_modules/node-mocks-http": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/node-mocks-http/-/node-mocks-http-1.12.1.tgz",
+      "integrity": "sha512-jrA7Sn3qI6GsHgWtUW3gMj0vO6Yz0nJjzg3jRZYjcfj4tzi8oWPauDK1qHVJoAxTbwuDHF1JiM9GISZ/ocI/ig==",
+      "dev": true,
+      "dependencies": {
+        "accepts": "^1.3.7",
+        "content-disposition": "^0.5.3",
+        "depd": "^1.1.0",
+        "fresh": "^0.5.2",
+        "merge-descriptors": "^1.0.1",
+        "methods": "^1.1.2",
+        "mime": "^1.3.4",
+        "parseurl": "^1.3.3",
+        "range-parser": "^1.2.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/node-mocks-http/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.6",
@@ -8733,6 +8800,14 @@
         "@types/node": "*"
       }
     },
+    "@types/http-status-codes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-status-codes/-/http-status-codes-1.2.0.tgz",
+      "integrity": "sha512-vjpjevMaxtrtdrrV/TQNIFT7mKL8nvIKG7G/LjMDZdVvqRxRg5SNfGkeuSaowVc0rbK8xDA2d/Etunyb5GyzzA==",
+      "requires": {
+        "http-status-codes": "*"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "dev": true
@@ -8759,6 +8834,15 @@
       "requires": {
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
+      }
+    },
+    "@types/jest-when": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@types/jest-when/-/jest-when-3.5.2.tgz",
+      "integrity": "sha512-1WP+wJDW7h4TYAVLoIebxRIVv8GPk66Qsq2nU7PkwKZ6usurnDQZgk0DfBNKAJ9gVzapCXSV53Vn/3nBHBNzAw==",
+      "dev": true,
+      "requires": {
+        "@types/jest": "*"
       }
     },
     "@types/json-schema": {
@@ -9126,7 +9210,9 @@
         "@tsconfig/node16": "1.0.3",
         "@types/body-parser": "1.19.2",
         "@types/express": "4.17.14",
+        "@types/http-status-codes": "1.2.0",
         "@types/jest": "29.2.3",
+        "@types/jest-when": "3.5.2",
         "@types/lodash": "4.14.189",
         "@types/node": "18.11.9",
         "@types/supertest": "2.0.12",
@@ -9143,8 +9229,11 @@
         "eslint-config-prettier": "8.5.0",
         "eslint-plugin-import": "2.26.0",
         "express": "4.18.2",
+        "http-status-codes": "2.2.0",
         "jest": "29.3.1",
+        "jest-when": "3.5.2",
         "lodash": "4.17.21",
+        "node-mocks-http": "1.12.1",
         "supertest": "6.3.1",
         "tsup": "6.5.0",
         "typescript": "4.8.4",
@@ -10296,6 +10385,11 @@
         "toidentifier": "1.0.1"
       }
     },
+    "http-status-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+      "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng=="
+    },
     "human-signals": {
       "version": "2.1.0",
       "dev": true
@@ -11321,6 +11415,13 @@
         }
       }
     },
+    "jest-when": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/jest-when/-/jest-when-3.5.2.tgz",
+      "integrity": "sha512-4rDvnhaWh08RcPsoEVXgxRnUIE9wVIbZtGqZ5x2Wm9Ziz9aQs89PipQFmOK0ycbEhVAgiV3MUeTXp3Ar4s2FcQ==",
+      "dev": true,
+      "requires": {}
+    },
     "jest-worker": {
       "version": "29.3.1",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.3.1.tgz",
@@ -11569,6 +11670,32 @@
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true
+    },
+    "node-mocks-http": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/node-mocks-http/-/node-mocks-http-1.12.1.tgz",
+      "integrity": "sha512-jrA7Sn3qI6GsHgWtUW3gMj0vO6Yz0nJjzg3jRZYjcfj4tzi8oWPauDK1qHVJoAxTbwuDHF1JiM9GISZ/ocI/ig==",
+      "dev": true,
+      "requires": {
+        "accepts": "^1.3.7",
+        "content-disposition": "^0.5.3",
+        "depd": "^1.1.0",
+        "fresh": "^0.5.2",
+        "merge-descriptors": "^1.0.1",
+        "methods": "^1.1.2",
+        "mime": "^1.3.4",
+        "parseurl": "^1.3.3",
+        "range-parser": "^1.2.0",
+        "type-is": "^1.6.18"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+          "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+          "dev": true
+        }
+      }
     },
     "node-releases": {
       "version": "2.0.6",


### PR DESCRIPTION
Router code was not easily testable (and was not tested) so I extracted a controller from it and added some tests.

I also added some validation on the request input to prevent exceptions later in the code (eg when the URL was not valid).