### PR TITLE
fix: use node:https to send request to sellers using https

### DIFF
--- a/server/apps/backend/src/app.spec.ts
+++ b/server/apps/backend/src/app.spec.ts
@@ -2,8 +2,8 @@ import bodyParser from 'body-parser';
 import express, { Express } from 'express';
 import request from 'supertest';
 import Configuration from './config';
+import { buildWithDefaults } from './fixtures';
 import { Sellers } from './repositories';
-import { buildWithDefaults } from './repositories/Seller';
 import routes from './routes';
 import { SellerService } from './services';
 

--- a/server/apps/backend/src/fixtures/index.ts
+++ b/server/apps/backend/src/fixtures/index.ts
@@ -1,4 +1,10 @@
-export { cashHistory, seller1, seller2, sellers } from './sellers.fixture';
+export {
+  buildWithDefaults,
+  cashHistory,
+  seller1,
+  seller2,
+  sellers,
+} from './sellers.fixture';
 export {
   missingNameSellerRequest,
   missingPasswordSellerRequest,

--- a/server/apps/backend/src/fixtures/sellers.fixture.ts
+++ b/server/apps/backend/src/fixtures/sellers.fixture.ts
@@ -27,3 +27,12 @@ export const cashHistory: CashHistory = {
   },
   lastIteration: 4,
 };
+
+export const buildWithDefaults = (values: Partial<Seller>): Seller => ({
+  name: 'John',
+  password: '123456',
+  url: new URL('https://192.168.0.1:3000'),
+  cash: 0,
+  online: true,
+  ...values,
+});

--- a/server/apps/backend/src/fixtures/sellers.fixture.ts
+++ b/server/apps/backend/src/fixtures/sellers.fixture.ts
@@ -1,3 +1,4 @@
+import { URL } from 'node:url';
 import { Seller } from '../repositories';
 import { CashHistory } from '../services/SellerService';
 
@@ -5,20 +6,16 @@ export const seller1: Seller = {
   name: 'John',
   cash: 1000,
   online: true,
-  hostname: 'http://192.168.0.1',
-  path: '',
+  url: new URL('http://192.168.0.1:8080'),
   password: '12345',
-  port: '8080',
 };
 
 export const seller2: Seller = {
   name: 'Alex',
   cash: 1500,
   online: false,
-  hostname: 'https://192.168.0.2',
-  path: '',
+  url: new URL('http://192.168.0.2:8080'),
   password: '12345',
-  port: '8080',
 };
 
 export const sellers = [seller1, seller2];

--- a/server/apps/backend/src/repositories/Seller.ts
+++ b/server/apps/backend/src/repositories/Seller.ts
@@ -1,19 +1,17 @@
+import { URL } from 'node:url';
+
 export type Seller = {
   name: string;
   password?: string;
-  hostname: string;
-  port: string;
-  path?: string;
+  url: URL;
   cash: number;
   online?: boolean;
 };
 
-export const buildWithDefaults = (values: Partial<Seller>) => ({
+export const buildWithDefaults = (values: Partial<Seller>): Seller => ({
   name: 'John',
   password: '123456',
-  hostname: '192.168.0.1',
-  port: '3000',
-  path: '/',
+  url: new URL('https://192.168.0.1:3000'),
   cash: 0,
   online: true,
   ...values,

--- a/server/apps/backend/src/repositories/Seller.ts
+++ b/server/apps/backend/src/repositories/Seller.ts
@@ -7,12 +7,3 @@ export type Seller = {
   cash: number;
   online?: boolean;
 };
-
-export const buildWithDefaults = (values: Partial<Seller>): Seller => ({
-  name: 'John',
-  password: '123456',
-  url: new URL('https://192.168.0.1:3000'),
-  cash: 0,
-  online: true,
-  ...values,
-});

--- a/server/apps/backend/src/repositories/Sellers.spec.ts
+++ b/server/apps/backend/src/repositories/Sellers.spec.ts
@@ -1,38 +1,29 @@
-import { Seller, buildWithDefaults } from './Seller';
+import { URL } from "node:url";
+import { buildWithDefaults } from './Seller';
 import Sellers from './Sellers';
 
 describe('Sellers', () => {
-  let bob: Seller;
   let sellers: Sellers;
 
   beforeEach(() => {
-    bob = {
-      name: 'bob',
-      hostname: 'hostname',
-      port: '3000',
-      path: '/path',
-      cash: 0.0,
-    };
     sellers = new Sellers();
   });
 
   it('should return all sellers sorted by cash in decreasing order', () => {
+    const bob = buildWithDefaults({
+      name: 'bob',
+      cash: 0.0,
+    });
     sellers.save(bob);
-    const alice = {
+    const alice = buildWithDefaults({
       name: 'alice',
-      hostname: 'hostname',
-      port: '3001',
-      path: '/path',
       cash: 10.0,
-    };
+    });
     sellers.save(alice);
-    const carol = {
+    const carol = buildWithDefaults({
       name: 'carol',
-      hostname: 'hostname',
-      port: '3002',
-      path: '/path',
       cash: 5.0,
-    };
+    });
     sellers.save(carol);
 
     expect(sellers.all()[0]).toEqual(alice);
@@ -41,24 +32,33 @@ describe('Sellers', () => {
   });
 
   it('should add sellers', () => {
+    const bob = buildWithDefaults({
+      name: 'bob',
+      cash: 0.0,
+    });
     sellers.save(bob);
 
     expect(sellers.all()).toContain(bob);
   });
 
   it('should update sellers data and preserve cash & cash history', () => {
+    const bob = buildWithDefaults({
+      name: 'bob',
+      cash: 0.0,
+      url: new URL('http://192.168.0.1:8080'),
+    });
     sellers.save(bob);
     sellers.updateCash(bob.name, 42, 1);
 
     const newBob = buildWithDefaults({
       name: bob.name,
-      hostname: 'new hostname',
+      url: new URL('https://192.168.0.1:3000'),
     });
     sellers.save(newBob);
 
     expect(sellers.all().length).toBe(1);
     const updatedBob = sellers.get(bob.name);
-    expect(updatedBob.hostname).toEqual('new hostname');
+    expect(updatedBob.url.toString()).toEqual('https://192.168.0.1:3000/');
     expect(updatedBob.cash).toBe(42);
     expect(sellers.cashHistory).toEqual({ bob: [0, 42] });
   });
@@ -66,6 +66,10 @@ describe('Sellers', () => {
   it('should count sellers', () => {
     expect(sellers.count()).toBe(0);
 
+    const bob = buildWithDefaults({
+      name: 'bob',
+      cash: 0.0,
+    });
     sellers.save(bob);
 
     expect(sellers.count()).toBe(1);
@@ -74,12 +78,20 @@ describe('Sellers', () => {
   it('should say when there are sellers or not', () => {
     expect(sellers.isEmpty()).toBeTruthy();
 
+    const bob = buildWithDefaults({
+      name: 'bob',
+      cash: 0.0,
+    });
     sellers.save(bob);
 
     expect(sellers.isEmpty()).toBeFalsy();
   });
 
   it("should update seller's cash", () => {
+    const bob = buildWithDefaults({
+      name: 'bob',
+      cash: 0.0,
+    });
     sellers.save(bob);
 
     sellers.updateCash('bob', 100, 0);
@@ -88,6 +100,10 @@ describe('Sellers', () => {
   });
 
   it('should track cash evolution on cash update by iteration', () => {
+    const bob = buildWithDefaults({
+      name: 'bob',
+      cash: 0.0,
+    });
     sellers.save(bob);
 
     sellers.updateCash('bob', 100, 0);
@@ -96,6 +112,10 @@ describe('Sellers', () => {
   });
 
   it('should track cash evolution on cash update by iteration and fill missing iterations with last value', () => {
+    const bob = buildWithDefaults({
+      name: 'bob',
+      cash: 0.0,
+    });
     sellers.save(bob);
 
     sellers.updateCash('bob', 100, 3);

--- a/server/apps/backend/src/repositories/Sellers.spec.ts
+++ b/server/apps/backend/src/repositories/Sellers.spec.ts
@@ -1,5 +1,5 @@
-import { URL } from "node:url";
-import { buildWithDefaults } from './Seller';
+import { URL } from 'node:url';
+import { buildWithDefaults } from '../fixtures';
 import Sellers from './Sellers';
 
 describe('Sellers', () => {

--- a/server/apps/backend/src/services/OrderService.spec.ts
+++ b/server/apps/backend/src/services/OrderService.spec.ts
@@ -1,3 +1,4 @@
+import { URL } from 'node:url';
 import _ from 'lodash';
 import Configuration from '../config';
 import { Countries } from '../repositories';
@@ -28,17 +29,17 @@ describe('Order Service', () => {
     const cashUpdater = () => {};
     const onError = () => {};
 
+    const url = new URL('https://localhost:3000/test');
     orderService.sendOrder(
-      buildWithDefaults({ hostname: 'localhost', port: '3000', path: '/test' }),
+      buildWithDefaults({ url }),
       order,
       cashUpdater,
       onError
     );
 
     expect(utils.post).toHaveBeenCalledWith(
-      'localhost',
-      '3000',
-      '/test/order',
+      url,
+      '/order',
       order,
       cashUpdater,
       onError

--- a/server/apps/backend/src/services/OrderService.spec.ts
+++ b/server/apps/backend/src/services/OrderService.spec.ts
@@ -1,8 +1,8 @@
 import { URL } from 'node:url';
 import _ from 'lodash';
 import Configuration from '../config';
+import { buildWithDefaults } from '../fixtures';
 import { Countries } from '../repositories';
-import { buildWithDefaults } from '../repositories/Seller';
 import utils from '../utils';
 import OrderService from './OrderService';
 import Reductions from './reduction';

--- a/server/apps/backend/src/services/OrderService.ts
+++ b/server/apps/backend/src/services/OrderService.ts
@@ -29,14 +29,7 @@ export default class OrderService {
         )}`
       )
     );
-    utils.post(
-      seller.hostname,
-      seller.port,
-      `${seller.path}/order`,
-      order,
-      cashUpdater,
-      logError
-    );
+    utils.post(seller.url, '/order', order, cashUpdater, logError);
   }
 
   public createOrder(reduction: Reduction): Order {

--- a/server/apps/backend/src/services/SellerService.spec.ts
+++ b/server/apps/backend/src/services/SellerService.spec.ts
@@ -1,7 +1,7 @@
 import { URL } from 'node:url';
 import Configuration, { Settings } from '../config';
+import { buildWithDefaults } from '../fixtures';
 import { Sellers } from '../repositories';
-import { buildWithDefaults } from '../repositories/Seller';
 import utils from '../utils';
 import SellerService from './SellerService';
 

--- a/server/apps/backend/src/services/SellerService.spec.ts
+++ b/server/apps/backend/src/services/SellerService.spec.ts
@@ -1,5 +1,6 @@
+import { URL } from 'node:url';
 import Configuration, { Settings } from '../config';
-import { Seller, Sellers } from '../repositories';
+import { Sellers } from '../repositories';
 import { buildWithDefaults } from '../repositories/Seller';
 import utils from '../utils';
 import SellerService from './SellerService';
@@ -7,20 +8,10 @@ import SellerService from './SellerService';
 describe('Seller Service', () => {
   let sellersRepository: Sellers;
   let sellerService: SellerService;
-  let bob: Seller;
   let configurationData: Settings;
 
   beforeEach(() => {
     jest.spyOn(utils, 'post').mockImplementation(jest.fn());
-
-    bob = {
-      name: 'bob',
-      hostname: 'localhost',
-      port: '3000',
-      path: '/path',
-      cash: 0,
-      online: false,
-    };
     sellersRepository = new Sellers();
 
     configurationData = { cashFreeze: false } as Settings;
@@ -38,17 +29,7 @@ describe('Seller Service', () => {
     expect(actual?.name).toBe('bob');
     expect(actual?.cash).toBe(0);
     expect(actual?.online).toBe(false);
-  });
-
-  it('should register new seller with an empty path', () => {
-    sellerService.register('http://localhost:3000', 'bob');
-    const sellers = sellerService.allSellers();
-    expect(sellers.length).toBe(1);
-    const actual = sellers.shift();
-    expect(actual?.name).toBe('bob');
-    expect(actual?.cash).toBe(0);
-    expect(actual?.online).toBe(false);
-    expect(actual?.path).toBe('/');
+    expect(actual?.url.toString()).toBe('http://localhost:3000/path');
   });
 
   it("should compute seller's cash based on the order's amount", () => {
@@ -134,14 +115,16 @@ describe('Seller Service', () => {
   it('should send notification to seller', () => {
     const message = { type: 'INFO' as const, content: 'test' };
 
+    const url = new URL('https://localhost:3000/path');
+    const bob = buildWithDefaults({
+      name: 'bob',
+      url,
+      cash: 0,
+      online: false,
+    });
     sellerService.notify(bob, message);
 
-    expect(utils.post).toHaveBeenCalledWith(
-      'localhost',
-      '3000',
-      '/path/feedback',
-      message
-    );
+    expect(utils.post).toHaveBeenCalledWith(url, '/feedback', message);
   });
 
   it("should get seller's cash history reduced in chunks of N iterations", () => {

--- a/server/apps/backend/src/services/SellerService.ts
+++ b/server/apps/backend/src/services/SellerService.ts
@@ -1,4 +1,4 @@
-import url from 'node:url';
+import { URL } from 'node:url';
 import _ from 'lodash';
 import Configuration from '../config';
 import { messageFromError } from '../error-utils';
@@ -73,13 +73,11 @@ export default class SellerService {
   }
 
   public register(sellerUrl: string, name: string, password?: string): void {
-    const parsedUrl = new url.URL(sellerUrl);
+    const parsedUrl = new URL(sellerUrl);
     const seller: Seller = {
       name,
       password,
-      hostname: parsedUrl.hostname,
-      port: parsedUrl.port,
-      path: parsedUrl.pathname,
+      url: parsedUrl,
       cash: 0.0,
       online: false,
     };
@@ -138,12 +136,7 @@ export default class SellerService {
   }
 
   public notify(seller: Seller, message: Message): void {
-    utils.post(
-      seller.hostname,
-      seller.port,
-      `${seller.path}/feedback`,
-      message
-    );
+    utils.post(seller.url, '/feedback', message);
 
     if (message.type === 'ERROR') {
       logger.error(`Notifying ${seller.name}: ${message.content}`);

--- a/server/apps/backend/src/services/dispatcher/BadRequest.spec.ts
+++ b/server/apps/backend/src/services/dispatcher/BadRequest.spec.ts
@@ -1,7 +1,7 @@
 import { IncomingMessage } from 'node:http';
 import Configuration, { BadRequestMode } from '../../config';
+import { buildWithDefaults } from '../../fixtures';
 import { Sellers } from '../../repositories';
-import { buildWithDefaults } from '../../repositories/Seller';
 import SellerService from '../SellerService';
 import BadRequest from './BadRequest';
 

--- a/server/apps/backend/src/services/dispatcher/Dispatcher.spec.ts
+++ b/server/apps/backend/src/services/dispatcher/Dispatcher.spec.ts
@@ -1,5 +1,6 @@
 import Configuration from '../../config';
 import { Sellers } from '../../repositories';
+import { buildWithDefaults } from '../../repositories/Seller';
 import OrderService from '../OrderService';
 import Reductions from '../reduction';
 import SellerService from '../SellerService';
@@ -175,20 +176,12 @@ describe('Dispatcher', () => {
 
   it('should send the same order to each seller using reduction', () => {
     jest.spyOn(configuration, 'all').mockReturnValue({});
-    const alice = {
+    const alice = buildWithDefaults({
       name: 'alice',
-      hostname: 'seller',
-      port: '8080',
-      path: '/',
-      cash: 0,
-    };
-    const bob = {
+    });
+    const bob = buildWithDefaults({
       name: 'bob',
-      hostname: 'seller',
-      port: '8081',
-      path: '/',
-      cash: 0,
-    };
+    });
     jest.spyOn(sellerService, 'addCash').mockImplementation(jest.fn());
     jest.spyOn(sellerService, 'allSellers').mockReturnValue([alice, bob]);
     const order = {

--- a/server/apps/backend/src/services/dispatcher/Dispatcher.spec.ts
+++ b/server/apps/backend/src/services/dispatcher/Dispatcher.spec.ts
@@ -1,6 +1,6 @@
 import Configuration from '../../config';
+import { buildWithDefaults } from '../../fixtures';
 import { Sellers } from '../../repositories';
-import { buildWithDefaults } from '../../repositories/Seller';
 import OrderService from '../OrderService';
 import Reductions from '../reduction';
 import SellerService from '../SellerService';

--- a/server/apps/backend/src/services/dispatcher/SellerCashUpdater.spec.ts
+++ b/server/apps/backend/src/services/dispatcher/SellerCashUpdater.spec.ts
@@ -1,6 +1,7 @@
 import { IncomingMessage } from 'node:http';
 import Configuration from '../../config';
 import { Sellers } from '../../repositories';
+import { buildWithDefaults } from '../../repositories/Seller';
 import OrderService from '../OrderService';
 import SellerService from '../SellerService';
 import SellerCashUpdater from './SellerCashUpdater';
@@ -19,13 +20,9 @@ describe("Seller's cash updater", () => {
   });
 
   it("should deduct a penalty when the sellers's response is neither 200 nor 404", () => {
-    const bob = {
+    const bob = buildWithDefaults({
       name: 'bob',
-      hostname: 'seller',
-      port: '8081',
-      path: '/',
-      cash: 0,
-    };
+    });
     jest.spyOn(sellerService, 'setOnline').mockImplementation(jest.fn());
     jest.spyOn(sellerService, 'updateCash').mockImplementation(jest.fn());
 
@@ -44,13 +41,9 @@ describe("Seller's cash updater", () => {
   });
 
   it("should NOT deduct a penalty when the sellers's response is 404", () => {
-    const bob = {
+    const bob = buildWithDefaults({
       name: 'bob',
-      hostname: 'seller',
-      port: '8081',
-      path: '/',
-      cash: 0,
-    };
+    });
     jest.spyOn(sellerService, 'setOnline').mockImplementation(jest.fn());
     jest.spyOn(sellerService, 'updateCash').mockImplementation(jest.fn());
 

--- a/server/apps/backend/src/services/dispatcher/SellerCashUpdater.spec.ts
+++ b/server/apps/backend/src/services/dispatcher/SellerCashUpdater.spec.ts
@@ -1,7 +1,7 @@
 import { IncomingMessage } from 'node:http';
 import Configuration from '../../config';
+import { buildWithDefaults } from '../../fixtures';
 import { Sellers } from '../../repositories';
-import { buildWithDefaults } from '../../repositories/Seller';
 import OrderService from '../OrderService';
 import SellerService from '../SellerService';
 import SellerCashUpdater from './SellerCashUpdater';


### PR DESCRIPTION
Use `node:https` to send request to sellers using HTTPS.

I refactored the `Seller` to save the URL instead of splitting it in several parts.

Fixes #2 